### PR TITLE
revert accent color with ehancement and more colors

### DIFF
--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -77,7 +77,6 @@
       }
     },
     "Accent color" : {
-      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -280,7 +279,6 @@
 
     },
     "Custom color" : {
-      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -778,6 +776,9 @@
 
     },
     "Running" : {
+
+    },
+    "S" : {
 
     },
     "seconds" : {

--- a/boringNotch/components/Calendar/BoringCalendar.swift
+++ b/boringNotch/components/Calendar/BoringCalendar.swift
@@ -85,13 +85,13 @@ struct WheelPicker: View {
     private func dayText(date: String, isSelected: Bool) -> some View {
         Text(date)
             .font(.caption2)
-            .foregroundStyle(isSelected ? Color.accentColor : .gray)
+            .foregroundStyle(isSelected ? Defaults[.accentColor] : .gray)
     }
 
     private func dateCircle(date: Date, isSelected: Bool) -> some View {
         ZStack {
             Circle()
-                .fill(isSelected ? Color.accentColor : .clear)
+                .fill(isSelected ? Defaults[.accentColor] : .clear)
                 .frame(width: 24, height: 24)
             Text("\(date.date)")
                 .font(.title3)

--- a/boringNotch/components/Clipboard/ClipboardTile.swift
+++ b/boringNotch/components/Clipboard/ClipboardTile.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import AppKit
+import Defaults
 
 struct ClipboardTile: View {
     let item: ClipboardData
@@ -24,7 +25,7 @@ struct ClipboardTile: View {
             .clipShape(RoundedRectangle(cornerRadius: 5))
             .overlay(
                 RoundedRectangle(cornerRadius: 5)
-                    .stroke(item.isPinned ? Color.accentColor.opacity(0.4) : Color.clear, lineWidth: 1)
+                    .stroke(item.isPinned ? Defaults[.accentColor].opacity(0.4) : Color.clear, lineWidth: 1)
             )
             .onHover { hovering in
                 withAnimation(.easeInOut(duration: 0.2)) {

--- a/boringNotch/components/HoverButton.swift
+++ b/boringNotch/components/HoverButton.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Defaults
 
 struct HoverButton: View {
     var icon: String
@@ -30,7 +31,7 @@ struct HoverButton: View {
                         .frame(width: size, height: size)
                         .overlay {
                             Image(systemName: icon)
-                                .foregroundColor(iconColor)
+                                .foregroundColor(isHovering ? Defaults[.accentColor] : iconColor)
                                 .contentTransition(contentTransition)
                                 .font(scale == .large ? .largeTitle : .body)
                         }

--- a/boringNotch/components/Live activities/SystemEventIndicatorModifier.swift
+++ b/boringNotch/components/Live activities/SystemEventIndicatorModifier.swift
@@ -121,6 +121,20 @@ struct DraggableProgressBar: View {
                             Color.clear,
                             radius: 8, x: 3)
                         .opacity(value.isZero ? 0 : 1)
+                    Group {
+                                           if Defaults[.enableGradient] {
+                                               Capsule()
+                                                   .fill(LinearGradient(colors: Defaults[.systemEventIndicatorUseAccent] ? [Defaults[.accentColor], Defaults[.accentColor].ensureMinimumBrightness(factor: 0.2)] : [.white, .white.opacity(0.2)], startPoint: .trailing, endPoint: .leading))
+                                                   .frame(width: max(0, min(geo.size.width * value, geo.size.width)))
+                                                   .shadow(color: Defaults[.systemEventIndicatorShadow] ? Defaults[.systemEventIndicatorUseAccent] ? Defaults[.accentColor].ensureMinimumBrightness(factor: 0.7) : .white : .clear, radius: 8, x: 3)
+                                           } else {
+                                               Capsule()
+                                                   .fill(Defaults[.systemEventIndicatorUseAccent] ? Defaults[.accentColor] : .white)
+                                                   .frame(width: max(0, min(geo.size.width * value, geo.size.width)))
+                                                   .shadow(color: Defaults[.systemEventIndicatorShadow] ? Defaults[.systemEventIndicatorUseAccent] ? Defaults[.accentColor].ensureMinimumBrightness(factor: 0.7) : .white : .clear, radius: 8, x: 3)
+                                           }
+                                       }
+                                       .opacity(value.isZero ? 0 : 1)
                 }
                 .gesture(
                     DragGesture(minimumDistance: 0)

--- a/boringNotch/components/Notch/NotchHomeView.swift
+++ b/boringNotch/components/Notch/NotchHomeView.swift
@@ -305,7 +305,8 @@ struct CustomSlider: View {
     @Binding var lastDragged: Date
     var onValueChange: ((Double) -> Void)?
     var thumbSize: CGFloat = 12
-
+    @State private var isHovering = false
+    
     var body: some View {
         GeometryReader { geometry in
             let width = geometry.size.width
@@ -322,8 +323,13 @@ struct CustomSlider: View {
 
                 // Filled track
                 Rectangle()
-                    .fill(color)
+                    .fill(dragging || isHovering ? Defaults[.accentColor] : color)
                     .frame(width: filledTrackWidth, height: height)
+                    .onHover { hovering in
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            isHovering = hovering
+                        }
+                    }
             }
             .cornerRadius(height / 2)
             .frame(height: 10)

--- a/boringNotch/components/Notch/NotchHomeView.swift
+++ b/boringNotch/components/Notch/NotchHomeView.swift
@@ -262,7 +262,7 @@ struct MusicSliderView: View {
                 range: 0 ... duration,
                 color: Defaults[.sliderColor] == SliderColorEnum.albumArt ? Color(
                     nsColor: color
-                ).ensureMinimumBrightness(factor: 0.8) : Defaults[.sliderColor] == SliderColorEnum.accent ? .accentColor : .white,
+                ).ensureMinimumBrightness(factor: 0.8) : Defaults[.sliderColor] == SliderColorEnum.accent ? Defaults[.accentColor] : .white,
                 dragging: $dragging,
                 lastDragged: $lastDragged,
                 onValueChange: onValueChange

--- a/boringNotch/components/Pomodoro/PomodoroMainView.swift
+++ b/boringNotch/components/Pomodoro/PomodoroMainView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Defaults
 
 struct PomodoroMainView: View {
     @ObservedObject var pomodoro = BoringPomodoro.shared
@@ -19,7 +20,7 @@ struct PomodoroMainView: View {
                 Text("Focus")
                     .font(.headline)
                     .minimumScaleFactor(0.5)
-                    .foregroundColor(.accentColor)
+                    .foregroundColor(Defaults[.accentColor])
                     .multilineTextAlignment(.center)
 
                 HStack(spacing: 10) {
@@ -58,7 +59,7 @@ struct PomodoroMainView: View {
                         Text(pomodoro.isPaused ? "Continue" :
                              (pomodoro.isRunning ? "Pause" : "Start Focus →"))
                             .foregroundColor(pomodoro.isPaused ? .green :
-                                (pomodoro.isRunning ? .yellow : .accentColor))
+                                (pomodoro.isRunning ? .yellow : Defaults[.accentColor]))
                             .font(.subheadline)
                             .minimumScaleFactor(0.5)
                             .lineLimit(1)

--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -74,6 +74,7 @@ struct SettingsView: View {
             .listStyle(SidebarListStyle())
             .toolbar(removing: .sidebarToggle)
             .navigationSplitViewColumnWidth(200)
+            .tint(Defaults[.accentColor])
         } detail: {
             Group {
                 switch selectedTab {
@@ -129,6 +130,9 @@ struct SettingsView: View {
 
 struct GeneralSettings: View {
     @State private var screens: [String] = NSScreen.screens.compactMap { $0.localizedName }
+    let accentColors: [Color] = [
+        .accentColor, .blue, .purple, .pink, .red, .orange, .yellow, .green, .gray, .brown, .mint
+    ]
     @EnvironmentObject var vm: BoringViewModel
     @ObservedObject var coordinator = BoringViewCoordinator.shared
 
@@ -146,9 +150,55 @@ struct GeneralSettings: View {
     @Default(.openNotchOnHover) var openNotchOnHover
     @Default(.alwaysHideInFullscreen) var alwaysHideInFullscreen
     @Default(.showClipboard) var showClipboard
+    @Default(.accentColor) var accentColor
     
     var body: some View {
         Form {
+            Section {
+                HStack {
+                    ForEach(accentColors.indices, id: \.self) { index in
+                        let color = accentColors[index]
+
+                        Button(action: {
+                            withAnimation {
+                                Defaults[.accentColor] = color
+                            }
+                        }) {
+                            ZStack {
+                                Circle()
+                                    .fill(color)
+                                    .frame(width: 20, height: 20)
+
+                                // Selected border
+                                if Defaults[.accentColor] == color {
+                                    Circle()
+                                        .stroke(Color.white, lineWidth: 2)
+                                        .frame(width: 20, height: 20)
+                                        .overlay(
+                                            Circle()
+                                                .fill(.white)
+                                                .frame(width: 7, height: 7)
+                                        )
+                                }
+
+                                // Add "S" label for the first (system) color
+                                if index == 0 {
+                                    Text("S")
+                                        .font(.caption2)
+                                        .foregroundColor(.white)
+                                }
+                            }
+                        }
+                        .buttonStyle(PlainButtonStyle())
+                    }
+                    Spacer()
+                    ColorPicker("Custom color", selection: $accentColor)
+                        .labelsHidden()
+                }
+            } header: {
+                Text("Accent color")
+            }
+
             Section {
                 Defaults.Toggle("Menubar icon", key: .menubarIcon)
                 LaunchAtLogin.Toggle("Launch at login")
@@ -240,6 +290,7 @@ struct GeneralSettings: View {
 
             gestureControls()
         }
+        .tint(Defaults[.accentColor])
         .toolbar {
             Button("Quit app") {
                 NSApp.terminate(self)
@@ -327,6 +378,7 @@ struct Charge: View {
                 Text("Battery Information")
             }
         }
+        .tint(Defaults[.accentColor])
         .navigationTitle("Battery")
     }
 }
@@ -401,6 +453,7 @@ struct Downloads: View {
                 }
             }
         }
+        .tint(Defaults[.accentColor])
         .navigationTitle("Downloads")
     }
 }
@@ -446,6 +499,7 @@ struct HUD: View {
                 }
             }
         }
+        .tint(Defaults[.accentColor])
         .navigationTitle("HUDs")
     }
 }
@@ -529,6 +583,7 @@ struct Media: View {
                     Defaults[.enableFullscreenMediaDetection] = newValue != .never
                 }
         }
+        .tint(Defaults[.accentColor])
         .navigationTitle("Media")
     }
 
@@ -584,6 +639,7 @@ struct CalendarSettings: View {
             }
         }
         // Add navigation title if it's missing or adjust as needed
+        .tint(Defaults[.accentColor])
         .navigationTitle("Calendar")
     }
 }
@@ -672,6 +728,7 @@ struct About: View {
 //            .controlSize(.extraLarge)
             CheckForUpdatesView(updater: updaterController.updater)
         }
+        .tint(Defaults[.accentColor])
         .navigationTitle("About")
     }
 }
@@ -688,6 +745,7 @@ struct Shelf: View {
                 }
             }
         }
+        .tint(Defaults[.accentColor])
         .navigationTitle("Shelf")
     }
 }
@@ -703,7 +761,7 @@ struct PomodoroSettings: View {
     var body: some View {
         Form {
             Section("Pomodoro Focus") {
-                Defaults.Toggle("Enable Pomodoro", key: .enablePomodoro)
+                Defaults.Toggle("Enable Pomodoro", key: .enablePomodoro).tint(Defaults[.accentColor])
                 
             Group {
                 Defaults.Toggle("Auto Hide", key: .autoHidePomodoro)
@@ -735,7 +793,10 @@ struct PomodoroSettings: View {
                             .foregroundStyle(.secondary)
                     }
                 }
-            }.disabled(!enablePomodoro)
+            }
+            .tint(Defaults[.accentColor])
+            .disabled(!enablePomodoro)
+                
         }
 
             Section("Sneak Peek") {
@@ -756,7 +817,9 @@ struct PomodoroSettings: View {
                             .foregroundStyle(.secondary)
                     }
                 }
-            }.disabled(!enablePomodoro)
+            }
+            .tint(Defaults[.accentColor])
+            .disabled(!enablePomodoro)
         }
         .navigationTitle("Pomodoro")
     }
@@ -875,6 +938,7 @@ struct Extensions: View {
                 }
             }
         }
+        .tint(Defaults[.accentColor])
         .navigationTitle("Extensions")
         // TipsView()
         // .padding(.horizontal, 19)
@@ -977,7 +1041,7 @@ struct Appearance: View {
                         .buttonStyle(PlainButtonStyle())
                         .padding(.vertical, 2)
                         .background(
-                            selectedListVisualizer != nil ? selectedListVisualizer == visualizer ? Color.accentColor : Color.clear : Color.clear,
+                            selectedListVisualizer != nil ? selectedListVisualizer == visualizer ? Defaults[.accentColor] : Color.clear : Color.clear,
                             in: RoundedRectangle(cornerRadius: 5)
                         )
                         .contentShape(Rectangle())
@@ -1123,7 +1187,7 @@ struct Appearance: View {
                                 .background(
                                     RoundedRectangle(cornerRadius: 20, style: .circular)
                                         .strokeBorder(
-                                            icon == selectedIcon ? Color.accentColor : .clear,
+                                            icon == selectedIcon ? Defaults[.accentColor] : .clear,
                                             lineWidth: 2.5
                                         )
                                 )
@@ -1136,7 +1200,7 @@ struct Appearance: View {
                                 .padding(.vertical, 3)
                                 .background(
                                     Capsule()
-                                        .fill(icon == selectedIcon ? Color.accentColor : .clear)
+                                        .fill(icon == selectedIcon ? Defaults[.accentColor] : .clear)
                                 )
                         }
                         .onTapGesture {
@@ -1156,6 +1220,7 @@ struct Appearance: View {
                 }
             }
         }
+        .tint(Defaults[.accentColor])
         .navigationTitle("Appearance")
     }
 
@@ -1185,6 +1250,7 @@ struct Shortcuts: View {
                 KeyboardShortcuts.Recorder("Toggle Notch Open:", name: .toggleNotchOpen)
             }
         }
+        .tint(Defaults[.accentColor])
         .navigationTitle("Shortcuts")
     }
 }

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -90,6 +90,7 @@ extension Defaults.Keys {
     static let mirrorShape = Key<MirrorShapeEnum>("mirrorShape", default: MirrorShapeEnum.rectangle)
     static let settingsIconInNotch = Key<Bool>("settingsIconInNotch", default: true)
     static let lightingEffect = Key<Bool>("lightingEffect", default: true)
+    static let accentColor = Key<Color>("accentColor", default: Color.blue)
     static let enableShadow = Key<Bool>("enableShadow", default: true)
     static let cornerRadiusScaling = Key<Bool>("cornerRadiusScaling", default: true)
     static let useModernCloseAnimation = Key<Bool>("useModernCloseAnimation", default: true)


### PR DESCRIPTION
revert accent color with ehancement and more colors

You can choose to set it to "S" which is system auto accent color, or choose the built-in color or even choose your loved color ;)

Accent color also set to the media controllers on hover

<img width="717" height="292" alt="Screenshot 2025-07-19 at 3 08 59 pm" src="https://github.com/user-attachments/assets/5a49ce97-b5f9-4bf4-a64f-69482c06e9ad" />
